### PR TITLE
Switch to `ubuntu-latest` action runner

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@ on: push
 
 jobs:
   build-n-publish:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     name: Build and publish Python 🐍 distributions 📦 to PyPI
     steps:
     - uses: SuffolkLITLab/ALActions/publish@main


### PR DESCRIPTION
The ubuntu-20.04 runner is deprecated (https://github.com/actions/runner-images/issues/11101), we should just be using the latest.